### PR TITLE
feat: add column sorting to missing-checkins-report

### DIFF
--- a/.squad/agents/cassini/history.md
+++ b/.squad/agents/cassini/history.md
@@ -95,3 +95,18 @@ Refactored app-add-book component to separate concerns:
 - No build or runtime errors introduced.
 
 **Note**: `uuid@8.3.2` (alert #214) was NOT overridden — already at latest 8.x release; vulnerability (buffer bounds check) not triggered by sockjs usage. Will assess separately if needed.
+
+## Day 7 — Column sorting for Missing Check-ins report
+
+**Feature**: Sortable column headers for Teacher, Last Name, Book Title, Reading Level, and Checked Out on the Possible Missing Check-ins report.
+
+**Changes**:
+- **`missing-checkins-report.component.ts`**: Added `sortColumn`, `sortDirection` properties; `sort(column)` method sorts `rows` in-place (toggles asc/desc on same column, resets to asc for new column); `getSortIndicator(column)` returns ▲/▼ or empty string. Reading Level sort is primary by readingLevel (case-insensitive), secondary by boxNumber parsed as integer (parseInt fallback 0).
+- **`missing-checkins-report.component.html`**: Added `(click)="sort(...)"` and `style="cursor:pointer"` to the five sortable `<th>` elements; non-sortable columns (Grade, First Name, Student Barcode, Barcode, Box Number) left unchanged.
+
+**Validation**: `ng build` succeeded (exit 0), no TypeScript errors.
+
+**Team Decision**: Column Sorting approach documented in `.squad/decisions.md` — in-place sort with no pipe or external dependency; read level uses two-key compare (level + box); sort state resets on fresh data load (acceptable UX).
+
+**Test Integration**: Halley added 13 comprehensive unit tests covering initial state, direction toggle, all 5 sortable columns, getSortIndicator return values, and cursor styling. Tests documented in orchestration log.
+

--- a/.squad/agents/halley/history.md
+++ b/.squad/agents/halley/history.md
@@ -62,3 +62,36 @@ Added Playwright E2E tests for the new "Possible Missing Check-ins" report featu
 
 **Verification:**
 - All 6 tests pass: `6 passed (1.3m)` with exit code 0
+
+### 2026-04-24: Column Sorting Tests for MissingCheckinsReportComponent (Completed)
+
+**Scope:**
+Added 13 unit tests for the column sorting feature being implemented by Cassini in `MissingCheckinsReportComponent`.
+
+**Files Modified:**
+- `HomeReadingLibraryWeb\ClientApp\src\app\components\missing-checkins-report\missing-checkins-report.component.spec.ts` — Added `describe('sorting', ...)` block with 13 tests
+
+**Test Cases Added (inside new `describe('sorting', ...)` block):**
+1. Initial state: `sortColumn === ''`, `sortDirection === 'asc'`
+2. `sort()` sets `sortColumn`
+3. First sort of a column defaults to `'asc'`
+4. Calling `sort()` twice on same column toggles direction to `'desc'`
+5. Sorting a different column resets direction to `'asc'`
+6. `teacherName` ascending: Mr. Jones before Ms. Smith
+7. `teacherName` descending: Ms. Smith before Mr. Jones
+8. `studentLastName` ascending: Doe before Williams
+9. `bookTitle` ascending: Green Eggs before The Cat
+10. `checkedOutDate` ascending: Jan before Feb ISO strings
+11. `readingLevel` ascending with numeric secondary sort on `boxNumber`: level 'B'/box 5 → 'B'/box 12 → 'C'
+12. `getSortIndicator()` returns `' ▲'` (active+asc), `' ▼'` (active+desc), `''` (inactive)
+13. Sortable `<th>` headers have `style.cursor === 'pointer'` after `runReport()`
+
+**Patterns Followed:**
+- Tests are written against the feature contract (TDD against Cassini's in-progress implementation)
+- Sort state tests call `component.sort()` directly; no async needed
+- Row-order tests set `component.rows = [...mockReportData]` directly to avoid async `runReport()` complexity
+- The `extraItem` (readingLevel 'B', boxNumber '5') defined at `describe` scope for test 11 reuse
+- Template/style test follows existing `setTimeout + done` async pattern
+- No new imports required beyond what the existing spec already imports
+
+**Status:** ✅ Complete — Cassini implemented all properties and methods per test contract; build verified clean.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -77,6 +77,28 @@ Use npm `overrides` block in `HomeReadingLibraryWeb\ClientApp\package.json` to f
 
 ---
 
+### 2026-04-24: Column Sorting for Missing Check-ins Report
+
+**By:** Cassini (Frontend Dev)  
+**Date:** 2026-04-24  
+**Status:** Implemented
+
+**Decision:**
+Sort `rows` in-place using `Array.sort()` directly on the component's data array. No pipe, no external library.
+
+**Rationale:**
+- The dataset is small (report output), so in-place sort is simple and efficient with no meaningful performance downside.
+- Avoids introducing an Angular pipe or a new dependency just for sort, keeping the component self-contained and consistent with the existing pattern in this codebase.
+- Reading Level sort uses a two-key comparison (readingLevel string → boxNumber integer) to handle the case where two books share the same level but differ in box; `parseInt(..., 10) || 0` safely handles empty/non-numeric boxNumber values.
+- Sort direction is toggled per-column (asc on first click, desc on second), with a reset to asc whenever a different column is clicked — standard UX convention.
+
+**Consequences:**
+- ✅ No new imports or dependencies needed.
+- ✅ `ng build` passes with no TypeScript errors.
+- ⚠️ Sort state resets if `runReport()` is called again (rows replaced); this is acceptable since a fresh data load should start unsorted.
+
+---
+
 ## Governance
 
 - All meaningful changes require team consensus

--- a/HomeReadingLibraryWeb/ClientApp/playwright/tests/auth/missing-checkins-report.spec.ts
+++ b/HomeReadingLibraryWeb/ClientApp/playwright/tests/auth/missing-checkins-report.spec.ts
@@ -85,7 +85,7 @@ test.describe('missing check-ins report — data and empty state', () => {
     await expect(page.getByRole('columnheader', { name: /last name/i })).toBeVisible();
     await expect(page.getByRole('columnheader', { name: /first name/i })).toBeVisible();
     await expect(page.getByRole('columnheader', { name: /book title/i })).toBeVisible();
-    await expect(page.getByRole('columnheader', { name: /barcode/i })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: /^barcode$/i })).toBeVisible();
     await expect(page.getByRole('columnheader', { name: /reading level/i })).toBeVisible();
     await expect(page.getByRole('columnheader', { name: /box number/i })).toBeVisible();
     await expect(page.getByRole('columnheader', { name: /checked out/i })).toBeVisible();

--- a/HomeReadingLibraryWeb/ClientApp/src/app/components/missing-checkins-report/missing-checkins-report.component.html
+++ b/HomeReadingLibraryWeb/ClientApp/src/app/components/missing-checkins-report/missing-checkins-report.component.html
@@ -15,16 +15,16 @@
     <table class="table table-striped table-hover" *ngIf="rows.length > 0">
       <thead>
         <tr>
-          <th>Teacher</th>
+          <th style="cursor:pointer" (click)="sort('teacherName')">Teacher{{ getSortIndicator('teacherName') }}</th>
           <th>Grade</th>
-          <th>Last Name</th>
+          <th style="cursor:pointer" (click)="sort('studentLastName')">Last Name{{ getSortIndicator('studentLastName') }}</th>
           <th>First Name</th>
           <th>Student Barcode</th>
-          <th>Book Title</th>
+          <th style="cursor:pointer" (click)="sort('bookTitle')">Book Title{{ getSortIndicator('bookTitle') }}</th>
           <th>Barcode</th>
-          <th>Reading Level</th>
+          <th style="cursor:pointer" (click)="sort('readingLevel')">Reading Level{{ getSortIndicator('readingLevel') }}</th>
           <th>Box Number</th>
-          <th>Checked Out</th>
+          <th style="cursor:pointer" (click)="sort('checkedOutDate')">Checked Out{{ getSortIndicator('checkedOutDate') }}</th>
         </tr>
       </thead>
       <tbody>

--- a/HomeReadingLibraryWeb/ClientApp/src/app/components/missing-checkins-report/missing-checkins-report.component.spec.ts
+++ b/HomeReadingLibraryWeb/ClientApp/src/app/components/missing-checkins-report/missing-checkins-report.component.spec.ts
@@ -219,7 +219,7 @@ describe('MissingCheckinsReportComponent', () => {
           const th = ths.find(el => el.textContent?.trim().startsWith(label));
           expect(th).withContext(`<th> for "${label}" should exist`).toBeTruthy();
           if (th) {
-            expect(th.style.cursor)
+            expect(window.getComputedStyle(th).cursor)
               .withContext(`<th> for "${label}" should have cursor: pointer`)
               .toBe('pointer');
           }

--- a/HomeReadingLibraryWeb/ClientApp/src/app/components/missing-checkins-report/missing-checkins-report.component.spec.ts
+++ b/HomeReadingLibraryWeb/ClientApp/src/app/components/missing-checkins-report/missing-checkins-report.component.spec.ts
@@ -105,4 +105,127 @@ describe('MissingCheckinsReportComponent', () => {
       done();
     }, 10);
   });
+
+  describe('sorting', () => {
+    const extraItem: MissingCheckinReportItem = {
+      studentFirstName: 'Alice',
+      studentLastName: 'Brown',
+      studentBarCode: 'STU003',
+      teacherName: 'Ms. Smith',
+      grade: '3',
+      bookTitle: 'Fox in Socks',
+      bookCopyBarCode: 'BC003',
+      readingLevel: 'B',
+      boxNumber: '5',
+      checkedOutDate: '2024-03-10T00:00:00Z'
+    };
+
+    it('should have sortColumn as empty string and sortDirection as asc initially', () => {
+      expect(component.sortColumn).toBe('');
+      expect(component.sortDirection).toBe('asc');
+    });
+
+    it('should set sortColumn when sort() is called', () => {
+      component.sort('teacherName');
+      expect(component.sortColumn).toBe('teacherName');
+    });
+
+    it('should default to asc direction on first sort of a column', () => {
+      component.sort('teacherName');
+      expect(component.sortDirection).toBe('asc');
+    });
+
+    it('should toggle direction to desc when same column is sorted twice', () => {
+      component.sort('teacherName');
+      component.sort('teacherName');
+      expect(component.sortDirection).toBe('desc');
+    });
+
+    it('should reset direction to asc when a different column is sorted', () => {
+      component.sort('teacherName');
+      component.sort('teacherName'); // now desc
+      component.sort('studentLastName'); // new column — resets to asc
+      expect(component.sortColumn).toBe('studentLastName');
+      expect(component.sortDirection).toBe('asc');
+    });
+
+    it('should sort teacherName ascending — Mr. Jones before Ms. Smith', () => {
+      component.rows = [...mockReportData];
+      component.sort('teacherName');
+      expect(component.rows[0].teacherName).toBe('Mr. Jones');
+      expect(component.rows[1].teacherName).toBe('Ms. Smith');
+    });
+
+    it('should sort teacherName descending — Ms. Smith before Mr. Jones', () => {
+      component.rows = [...mockReportData];
+      component.sort('teacherName'); // asc
+      component.sort('teacherName'); // desc
+      expect(component.rows[0].teacherName).toBe('Ms. Smith');
+      expect(component.rows[1].teacherName).toBe('Mr. Jones');
+    });
+
+    it('should sort studentLastName ascending — Doe before Williams', () => {
+      component.rows = [...mockReportData];
+      component.sort('studentLastName');
+      expect(component.rows[0].studentLastName).toBe('Doe');
+      expect(component.rows[1].studentLastName).toBe('Williams');
+    });
+
+    it('should sort bookTitle ascending — Green Eggs and Ham before The Cat in the Hat', () => {
+      component.rows = [...mockReportData];
+      component.sort('bookTitle');
+      expect(component.rows[0].bookTitle).toBe('Green Eggs and Ham');
+      expect(component.rows[1].bookTitle).toBe('The Cat in the Hat');
+    });
+
+    it('should sort checkedOutDate ascending — January date before February date', () => {
+      component.rows = [...mockReportData];
+      component.sort('checkedOutDate');
+      expect(component.rows[0].checkedOutDate).toBe('2024-01-15T00:00:00Z');
+      expect(component.rows[1].checkedOutDate).toBe('2024-02-20T00:00:00Z');
+    });
+
+    it('should sort readingLevel ascending with secondary sort by boxNumber numerically', () => {
+      component.rows = [mockReportData[0], extraItem, mockReportData[1]];
+      component.sort('readingLevel');
+      // Level 'B' rows first (box 5 before box 12), then level 'C'
+      expect(component.rows[0].readingLevel).toBe('B');
+      expect(component.rows[0].boxNumber).toBe('5');
+      expect(component.rows[1].readingLevel).toBe('B');
+      expect(component.rows[1].boxNumber).toBe('12');
+      expect(component.rows[2].readingLevel).toBe('C');
+    });
+
+    it('should return correct sort indicators from getSortIndicator()', () => {
+      component.sort('teacherName'); // asc
+      expect(component.getSortIndicator('teacherName')).toBe(' ▲');
+      expect(component.getSortIndicator('bookTitle')).toBe('');
+
+      component.sort('teacherName'); // desc
+      expect(component.getSortIndicator('teacherName')).toBe(' ▼');
+      expect(component.getSortIndicator('bookTitle')).toBe('');
+    });
+
+    it('should render sortable headers with cursor pointer style after runReport()', (done) => {
+      component.runReport();
+
+      setTimeout(() => {
+        fixture.detectChanges();
+        const compiled: HTMLElement = fixture.nativeElement;
+        const ths = Array.from(compiled.querySelectorAll('th'));
+        const sortableLabels = ['Teacher', 'Last Name', 'Book Title', 'Reading Level', 'Checked Out'];
+
+        sortableLabels.forEach(label => {
+          const th = ths.find(el => el.textContent?.trim().startsWith(label));
+          expect(th).withContext(`<th> for "${label}" should exist`).toBeTruthy();
+          if (th) {
+            expect(th.style.cursor)
+              .withContext(`<th> for "${label}" should have cursor: pointer`)
+              .toBe('pointer');
+          }
+        });
+        done();
+      }, 10);
+    });
+  });
 });

--- a/HomeReadingLibraryWeb/ClientApp/src/app/components/missing-checkins-report/missing-checkins-report.component.ts
+++ b/HomeReadingLibraryWeb/ClientApp/src/app/components/missing-checkins-report/missing-checkins-report.component.ts
@@ -2,17 +2,20 @@ import { Component } from '@angular/core';
 import { BaggyBookService } from '../../services/baggy-book.service';
 import { MissingCheckinReportItem } from '../../entities/missing-checkin-report-item';
 
+type SortColumn = 'teacherName' | 'studentLastName' | 'bookTitle' | 'readingLevel' | 'checkedOutDate';
+
 @Component({
   selector: 'app-missing-checkins-report',
   templateUrl: './missing-checkins-report.component.html',
   styleUrls: ['./missing-checkins-report.component.css'],
   standalone: false
 })
+
 export class MissingCheckinsReportComponent {
   rows: MissingCheckinReportItem[] = [];
   loading = false;
   hasRun = false;
-  sortColumn = '';
+  sortColumn: SortColumn | '' = '';
   sortDirection: 'asc' | 'desc' = 'asc';
 
   constructor(private baggyBookService: BaggyBookService) { }
@@ -24,6 +27,8 @@ export class MissingCheckinsReportComponent {
         this.rows = data;
         this.loading = false;
         this.hasRun = true;
+        this.sortColumn = '';
+        this.sortDirection = 'asc';
       },
       error: () => {
         this.loading = false;
@@ -32,7 +37,7 @@ export class MissingCheckinsReportComponent {
     });
   }
 
-  sort(column: string): void {
+  sort(column: SortColumn): void {
     if (this.sortColumn === column) {
       this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
     } else {
@@ -65,7 +70,7 @@ export class MissingCheckinsReportComponent {
     });
   }
 
-  getSortIndicator(column: string): string {
+  getSortIndicator(column: SortColumn): string {
     if (this.sortColumn !== column) return '';
     return this.sortDirection === 'asc' ? ' ▲' : ' ▼';
   }

--- a/HomeReadingLibraryWeb/ClientApp/src/app/components/missing-checkins-report/missing-checkins-report.component.ts
+++ b/HomeReadingLibraryWeb/ClientApp/src/app/components/missing-checkins-report/missing-checkins-report.component.ts
@@ -12,6 +12,8 @@ export class MissingCheckinsReportComponent {
   rows: MissingCheckinReportItem[] = [];
   loading = false;
   hasRun = false;
+  sortColumn = '';
+  sortDirection: 'asc' | 'desc' = 'asc';
 
   constructor(private baggyBookService: BaggyBookService) { }
 
@@ -28,5 +30,43 @@ export class MissingCheckinsReportComponent {
         this.hasRun = true;
       }
     });
+  }
+
+  sort(column: string): void {
+    if (this.sortColumn === column) {
+      this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
+    } else {
+      this.sortColumn = column;
+      this.sortDirection = 'asc';
+    }
+
+    const dir = this.sortDirection === 'asc' ? 1 : -1;
+
+    this.rows.sort((a, b) => {
+      switch (column) {
+        case 'teacherName':
+          return dir * a.teacherName.toLowerCase().localeCompare(b.teacherName.toLowerCase());
+        case 'studentLastName':
+          return dir * a.studentLastName.toLowerCase().localeCompare(b.studentLastName.toLowerCase());
+        case 'bookTitle':
+          return dir * a.bookTitle.toLowerCase().localeCompare(b.bookTitle.toLowerCase());
+        case 'readingLevel': {
+          const lvlCmp = a.readingLevel.toLowerCase().localeCompare(b.readingLevel.toLowerCase());
+          if (lvlCmp !== 0) return dir * lvlCmp;
+          const aBox = parseInt(a.boxNumber, 10) || 0;
+          const bBox = parseInt(b.boxNumber, 10) || 0;
+          return dir * (aBox - bBox);
+        }
+        case 'checkedOutDate':
+          return dir * a.checkedOutDate.localeCompare(b.checkedOutDate);
+        default:
+          return 0;
+      }
+    });
+  }
+
+  getSortIndicator(column: string): string {
+    if (this.sortColumn !== column) return '';
+    return this.sortDirection === 'asc' ? ' ▲' : ' ▼';
   }
 }


### PR DESCRIPTION
Cassini implemented sortable columns (Teacher, Last Name, Book Title, Reading Level, Checked Out) with in-place Array.sort, direction toggle, and two-key sort for reading level.

Halley added 13 unit tests covering initial state, direction toggling, all 5 sortable columns, getSortIndicator return values, and cursor styling on headers.

- Missing Check-ins Report component now supports interactive sorting
- ng build verified clean (no TypeScript errors)
- Decision documented in .squad/decisions.md
- Orchestration logs created for both agents