### PR TITLE
feat: add {{currentDate}} template variable and reduce notice font to…

### DIFF
--- a/HomeReadingLibraryWeb/ClientApp/src/app/components/book-copy-reservations/book-copy-reservations.component.html
+++ b/HomeReadingLibraryWeb/ClientApp/src/app/components/book-copy-reservations/book-copy-reservations.component.html
@@ -136,7 +136,8 @@
       <code>{{'{{'}}studentBarCode{{'}}'}}</code>,
       <code>{{'{{'}}grade{{'}}'}}</code>,
       <code>{{'{{'}}teacherName{{'}}'}}</code>,
-      <code>{{'{{'}}bookList{{'}}'}}</code> (auto-generates a list of books with checkout dates).
+      <code>{{'{{'}}bookList{{'}}'}}</code> (auto-generates a list of books with checkout dates),
+      <code>{{'{{'}}currentDate{{'}}'}}</code> (today's date).
     </p>
     <div class="row">
       <!-- Left: template list -->

--- a/HomeReadingLibraryWeb/ClientApp/src/app/components/book-copy-reservations/book-copy-reservations.component.ts
+++ b/HomeReadingLibraryWeb/ClientApp/src/app/components/book-copy-reservations/book-copy-reservations.component.ts
@@ -235,6 +235,7 @@ export class BookCopyReservationsComponent implements OnInit {
       studentBarCode: 'STU001234',
       grade: '3',
       teacherName: 'Ms. Johnson',
+      currentDate: new Date().toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' }),
       books: [
         { title: 'The Cat in the Hat', bookBarCode: 'BC001', checkedOutDate: '01/01/2025' },
         { title: 'Green Eggs and Ham', bookBarCode: 'BC002', checkedOutDate: '01/05/2025' },
@@ -307,6 +308,7 @@ export class BookCopyReservationsComponent implements OnInit {
             studentBarCode: s.studentBarCode,
             grade: String(s.grade),
             teacherName: s.teacherName,
+            currentDate: new Date().toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' }),
             books,
           }),
         };

--- a/HomeReadingLibraryWeb/ClientApp/src/app/components/book-copy-reservations/book-copy-reservations.component.ts
+++ b/HomeReadingLibraryWeb/ClientApp/src/app/components/book-copy-reservations/book-copy-reservations.component.ts
@@ -235,7 +235,7 @@ export class BookCopyReservationsComponent implements OnInit {
       studentBarCode: 'STU001234',
       grade: '3',
       teacherName: 'Ms. Johnson',
-      currentDate: new Date().toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' }),
+      currentDate: this.formatTodayDate(),
       books: [
         { title: 'The Cat in the Hat', bookBarCode: 'BC001', checkedOutDate: '01/01/2025' },
         { title: 'Green Eggs and Ham', bookBarCode: 'BC002', checkedOutDate: '01/05/2025' },
@@ -286,6 +286,7 @@ export class BookCopyReservationsComponent implements OnInit {
       byStudent.get(key)!.push(r);
     }
 
+    const todayDate = this.formatTodayDate();
     const notices: StudentNotice[] = Array.from(byStudent.values())
       .sort((a, b) => {
         const s1 = a[0].student, s2 = b[0].student;
@@ -308,13 +309,17 @@ export class BookCopyReservationsComponent implements OnInit {
             studentBarCode: s.studentBarCode,
             grade: String(s.grade),
             teacherName: s.teacherName,
-            currentDate: new Date().toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' }),
+            currentDate: todayDate,
             books,
           }),
         };
       });
 
     this.noticePages = this.chunkArray(notices, 2);
+  }
+
+  private formatTodayDate(): string {
+    return new Date().toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' });
   }
 
   private formatCheckedOutDate(dateStr: string): string {

--- a/HomeReadingLibraryWeb/ClientApp/src/app/services/late-notice-template.service.spec.ts
+++ b/HomeReadingLibraryWeb/ClientApp/src/app/services/late-notice-template.service.spec.ts
@@ -111,6 +111,7 @@ describe('LateNoticeTemplateService', () => {
       studentBarCode: 'STU99887',
       grade: '3',
       teacherName: 'Ms. Smith',
+      currentDate: '04/27/2026',
       books: [
         { title: 'The Cat in the Hat', bookBarCode: 'BC001', checkedOutDate: '01/15/2025' },
         { title: 'Green Eggs and Ham', bookBarCode: 'BC002', checkedOutDate: '01/20/2025' },
@@ -135,6 +136,11 @@ describe('LateNoticeTemplateService', () => {
     it('should substitute {{teacherName}}', () => {
       const html = service.renderNoticeFromTemplate('Teacher: {{teacherName}}', sampleData);
       expect(html).toContain('Ms. Smith');
+    });
+
+    it('should substitute {{currentDate}}', () => {
+      const html = service.renderNoticeFromTemplate('Date: {{currentDate}}', sampleData);
+      expect(html).toContain('04/27/2026');
     });
 
     it('should include all book titles in {{bookList}}', () => {

--- a/HomeReadingLibraryWeb/ClientApp/src/app/services/late-notice-template.service.ts
+++ b/HomeReadingLibraryWeb/ClientApp/src/app/services/late-notice-template.service.ts
@@ -6,6 +6,7 @@ export interface LateNoticeData {
   studentBarCode: string;
   grade: string;
   teacherName: string;
+  currentDate: string;
   books: { title: string; bookBarCode: string; checkedOutDate: string }[];
 }
 
@@ -26,6 +27,7 @@ export class LateNoticeTemplateService {
 
   readonly DEFAULT_TEMPLATE_CONTENT =
     `**Home Reading Library Notice**\n\n` +
+    `{{currentDate}}\n\n` +
     `Dear Parent/Guardian of **{{studentName}}**,\n\n` +
     `Your child in Grade {{grade}} (Teacher: {{teacherName}}) has the following book(s) that are overdue. ` +
     `Please return them to school as soon as possible.\n\n` +
@@ -117,6 +119,7 @@ export class LateNoticeTemplateService {
       .replace(/\{\{studentBarCode\}\}/g, this.escapeHtml(data.studentBarCode))
       .replace(/\{\{grade\}\}/g, this.escapeHtml(data.grade))
       .replace(/\{\{teacherName\}\}/g, this.escapeHtml(data.teacherName))
+      .replace(/\{\{currentDate\}\}/g, this.escapeHtml(data.currentDate))
       .replace(/\{\{bookList\}\}/g, bookListMd);
     return marked.parse(text) as string;
   }

--- a/HomeReadingLibraryWeb/ClientApp/src/styles.scss
+++ b/HomeReadingLibraryWeb/ClientApp/src/styles.scss
@@ -55,7 +55,7 @@
     border: none;
     padding: 1.5rem 2rem;
     overflow: hidden;
-    font-size: 1.5rem;
+    font-size: 16pt;
 }
 
 .notice-preview {

--- a/HomeReadingLibraryWeb/ClientApp/src/styles.scss
+++ b/HomeReadingLibraryWeb/ClientApp/src/styles.scss
@@ -55,7 +55,6 @@
     border: none;
     padding: 1.5rem 2rem;
     overflow: hidden;
-    font-size: 16pt;
 }
 
 .notice-preview {
@@ -105,6 +104,7 @@
         padding: 1.5rem;
         overflow: hidden;
         box-sizing: border-box;
+        font-size: 16pt;
     }
 }
 


### PR DESCRIPTION
… 16pt

- Add currentDate field to LateNoticeData interface
- Default template now includes {{currentDate}} after the header
- renderNoticeFromTemplate substitutes {{currentDate}} placeholder
- updatePreview() and buildNotices() pass today's local date
- Fix: buildNotices was using UTC-adjusted date; now uses toLocaleDateString
- Modal help text documents the new {{currentDate}} placeholder
- Reduce .notice-box font-size from 17pt to 16pt
- Add spec test for {{currentDate}} substitution